### PR TITLE
Fix failure to install golint

### DIFF
--- a/configure
+++ b/configure
@@ -201,7 +201,7 @@ main() {
     get_go_dep bazil.org/fuse
     get_go_dep github.com/dustin/go-humanize
     get_go_dep github.com/golang/glog
-    get_go_dep github.com/golang/lint/golint
+    get_go_dep golang.org/x/lint/golint
     get_go_dep github.com/mattn/go-sqlite3
     get_go_dep github.com/stretchr/testify/suite
 

--- a/configure
+++ b/configure
@@ -201,9 +201,9 @@ main() {
     get_go_dep bazil.org/fuse
     get_go_dep github.com/dustin/go-humanize
     get_go_dep github.com/golang/glog
-    get_go_dep golang.org/x/lint/golint
     get_go_dep github.com/mattn/go-sqlite3
     get_go_dep github.com/stretchr/testify/suite
+    get_go_dep golang.org/x/lint/golint
 
     [ "${enable_vscode}" = no ] || setup_vscode
 


### PR DESCRIPTION
Currently, `./configure` fails when installing `golint`. This is because the "go get" link has changed in https://github.com/golang/lint/commit/ead987a65e5c7e053cf9633f9eac1f734f6b4fe3#diff-04c6e90faac2675aa89e2176d2eec7d8. This fixes the install failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jmmv/sourcachefs/3)
<!-- Reviewable:end -->
