### PR TITLE
Fix import path for context

### DIFF
--- a/internal/fs/dir.go
+++ b/internal/fs/dir.go
@@ -15,6 +15,7 @@
 package fs
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -22,7 +23,6 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"github.com/jmmv/sourcachefs/internal/cache"
 	"github.com/jmmv/sourcachefs/internal/stats"

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -15,13 +15,13 @@
 package fs
 
 import (
+	"context"
 	"os"
 	"sync"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"github.com/jmmv/sourcachefs/internal/cache"
 	"github.com/jmmv/sourcachefs/internal/real"

--- a/internal/fs/symlink.go
+++ b/internal/fs/symlink.go
@@ -15,13 +15,13 @@
 package fs
 
 import (
+	"context"
 	"os"
 	"sync"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"github.com/jmmv/sourcachefs/internal/stats"
 )


### PR DESCRIPTION
This fixes the import path for the context package. The package is available in the standard library since [Go 1.7](https://golang.org/doc/go1.7).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jmmv/sourcachefs/5)
<!-- Reviewable:end -->
