### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+os:
+  - linux
+  - osx
+
+# Pin to macOS 10.12 (indirectly by using the Xcode 8.3 image).  We must do
+# this to get the OSXFUSE kernel extension to work because there currently
+# is no know way to programmatically grant permissions to load a kernel
+# extension in macOS 10.13.
+#
+# See https://github.com/travis-ci/travis-ci/issues/10017 for details.
+osx_image: xcode8.3
+
+language: go
+go_import_path: github.com/jmmv/sourcachefs
+
+go:
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
+
+install: ./admin/travis-install.sh
+
+script:
+  - ./configure
+  - make
+  - make check

--- a/admin/travis-install.sh
+++ b/admin/travis-install.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -e -u
+
+# Default to no features to avoid cluttering .travis.yml.
+: "${FEATURES:=}"
+
+install_fuse() {
+  case "${TRAVIS_OS_NAME}" in
+    linux)
+      sudo apt-get update
+      sudo apt-get install -qq fuse libfuse-dev pkg-config
+
+      sudo /bin/sh -c 'echo user_allow_other >>/etc/fuse.conf'
+      sudo chmod 644 /etc/fuse.conf
+      ;;
+
+    osx)
+      brew update
+      brew cask install osxfuse
+
+      sudo /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse
+      sudo sysctl -w vfs.generic.osxfuse.tunables.allow_other=1
+      ;;
+
+    *)
+      echo "Don't know how to install FUSE for OS ${TRAVIS_OS_NAME}" 1>&2
+      exit 1
+      ;;
+  esac
+}
+
+install_fuse

--- a/configure
+++ b/configure
@@ -192,7 +192,7 @@ main() {
     CLEANALLFILES="${CLEANALLFILES} src"
     mkdir -p src/github.com/jmmv
     [ -h src/github.com/jmmv/sourcachefs ] \
-        || ln -hfs ../../.. src/github.com/jmmv/sourcachefs \
+        || ln -fs ../../.. src/github.com/jmmv/sourcachefs \
         || err "Failed to create src directory to mimic GOPATH"
 
     CLEANALLFILES="${CLEANALLFILES} Makefile"


### PR DESCRIPTION
This adds `.travis.yml` to setup CI at Travis CI. `.travis.yml` is created based on sandboxfs's .travis.yml (esp., hacks for OSXFUSE), with minor changes.

- `sudo: required` is not added because it's deprecated in current infra as per [the blog post](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)
- `-h` option is removed from `ln` as the option is not available in Linux.

Currently, the build fails in running `make` due to the context package.  The PR #5 will resolve the issue.
I found two test failures after fixing the build issue. I'll create PRs to fix them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jmmv/sourcachefs/6)
<!-- Reviewable:end -->
