### PR TITLE
cache: strip monotonic clock reading for comparisons

### DIFF
--- a/internal/cache/metadata_test.go
+++ b/internal/cache/metadata_test.go
@@ -144,8 +144,9 @@ func (s *MetadataCacheSuite) TestPutNewOrUpdate() {
 func (s *MetadataCacheSuite) TestPutFileInfoAndGet() {
 	inode, err := s.cache.PutNewWithType("/path", 0)
 	s.Require().NoError(err)
-
-	fileInfo := newFileInfo("/path", 123, 0, time.Now())
+	// Strip monotonic clock reading for comparisons with require.Equal.
+	// See https://github.com/stretchr/testify/issues/502 for details.
+	fileInfo := newFileInfo("/path", 123, 0, time.Now().Round(0))
 	s.Require().NoError(s.cache.PutFileInfo(inode, fileInfo))
 
 	row := s.checkedGetFullEntry("/path", "file")


### PR DESCRIPTION
This fixes the test failure in `metadata_test.go`.
Comparing Time values with require.Equal fails because
one of the arguments has a monotonic clock reading and
because require.Equal doesn't use time.Equal for
comparison [1].

[1] https://github.com/stretchr/testify/issues/502

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jmmv/sourcachefs/7)
<!-- Reviewable:end -->
