### PR TITLE
fs: Ignore io.EOF for read

### DIFF
--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -16,6 +16,7 @@ package fs
 
 import (
 	"context"
+	"io"
 	"os"
 	"sync"
 
@@ -42,6 +43,9 @@ func (file *openFile) Read(ctx context.Context, req *fuse.ReadRequest, resp *fus
 	file.globals.stats.AccountCacheHit(stats.ReadFuseOp)
 	resp.Data = resp.Data[:req.Size]
 	n, err := file.reader.ReadAt(resp.Data, req.Offset)
+	if err == io.EOF {
+		err = nil
+	}
 	if err != nil {
 		glog.Errorf("read error: %s", err)
 	}


### PR DESCRIPTION
This fixes the test failure of `TestFunctional/TestBasicCaching` at `integration_test.go` in Linux.
(the test passes in macOS). At Travis, the error message we got was the following:

```
$ make check
GOPATH="/home/travis/gopath/src/github.com/jmmv/sourcachefs:/home/travis/gopath/src/github.com/jmmv/sourcachefs/deps" GOROOT="/home/travis/.gimme/versions/go1.13.5.linux.amd64" "/home/travis/.gimme/versions/go1.13.5.linux.amd64/bin/go" build -ldflags "-X github.com/jmmv/sourcachefs/stats.buildTimestamp=$(date "+%Y-%m-%dT%H:%M:%S") -X github.com/jmmv/sourcachefs/stats.buildWhere=$(id -un)@$(hostname) -X github.com/jmmv/sourcachefs/stats.gitRevision=$(git rev-parse HEAD)" -o bin/sourcachefs \
    ./cmd/sourcachefs/main.go
SOURCACHEFS="$(pwd)/bin/sourcachefs" GOPATH="/home/travis/gopath/src/github.com/jmmv/sourcachefs:/home/travis/gopath/src/github.com/jmmv/sourcachefs/deps" GOROOT="/home/travis/.gimme/versions/go1.13.5.linux.amd64" "/home/travis/.gimme/versions/go1.13.5.linux.amd64/bin/go" test \
    ./cmd/sourcachefs ./internal/cache
E1231 07:33:09.595371    6902 file.go:46] read error: EOF
E1231 07:33:09.595723    6902 file.go:46] read error: EOF
E1231 07:33:09.596380    6902 file.go:46] read error: EOF
E1231 07:33:09.596482    6902 file.go:46] read error: EOF
--- FAIL: TestFunctional (0.29s)
    --- FAIL: TestFunctional/TestBasicCaching (0.13s)
        integration_test.go:144: 
            	Error Trace:	integration_test.go:144
            	Error:      	Received unexpected error:
            	            	read /tmp/test892717633/mnt/a: input/output error
            	Test:       	TestFunctional/TestBasicCaching
        integration_test.go:148: 
            	Error Trace:	integration_test.go:148
            	Error:      	Received unexpected error:
            	            	read /tmp/test892717633/mnt/a: input/output error
            	Test:       	TestFunctional/TestBasicCaching
FAIL
FAIL	_/home/travis/gopath/src/github.com/jmmv/sourcachefs/cmd/sourcachefs	0.460s
```

The root cause is that FUSE read request returns 4096 bytes in Linux, which is larger than
the file size created in the failed test (3 bytes). `openFile.Read` ends up returning `io.EOF`
since `file.reader.ReadAt` (i.e., `os.File.ReadAt`) returns `io.EOF` when the number of bytes read is less than the size of the buffer in the parameter of the method (i.e., 3 < 4096 in this case).

In macOS, FUSE read request returns the same size with the test case. What I'm not sure is where
the difference comes from. I looked at the source of `bazil.org/fuse`, but it seems the request size
is determined by the FUSE implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jmmv/sourcachefs/8)
<!-- Reviewable:end -->
